### PR TITLE
Change admin files to dashboard

### DIFF
--- a/app/animals/dashboard/AnimalForm.tsx
+++ b/app/animals/dashboard/AnimalForm.tsx
@@ -59,7 +59,7 @@ const updateAnimalByIdMutation = gql`
   }
 `;
 
-export default function AdminDashboard() {
+export default function AnimalForm() {
   const [firstName, setFirstName] = useState('');
   const [type, setType] = useState('');
   const [accessory, setAccessory] = useState('');
@@ -122,7 +122,7 @@ export default function AdminDashboard() {
 
   return (
     <div>
-      AdminDashboard
+      Animal Dashboard
       <br />
       <label>
         First Name
@@ -165,7 +165,7 @@ export default function AdminDashboard() {
       {data.animals.map((animal) => {
         const isEditing = onEditId === animal.id;
         return (
-          <div key={`animal-div-${animal.id}`} className="animalAdmin">
+          <div key={`animal-div-${animal.id}`}>
             {isEditing ? (
               <input
                 value={firstNameOnEditInput}

--- a/app/animals/dashboard/page.tsx
+++ b/app/animals/dashboard/page.tsx
@@ -2,9 +2,9 @@ import { gql } from '@apollo/client';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getClient } from '../../../util/apolloClient';
-import AdminDashboard from './AdminDashboard';
+import AnimalForm from './AnimalForm';
 
-export default async function AdminPage() {
+export default async function DashboardPage() {
   const fakeSessionToken = cookies().get('fakeSession');
 
   const { data } = await getClient().query({
@@ -24,5 +24,5 @@ export default async function AdminPage() {
     redirect('/login');
   }
 
-  return <AdminDashboard />;
+  return <AnimalForm />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,7 +57,7 @@ export default async function RootLayout({
           >
             <Link href="/">Home</Link>
             <Link href="/animals">Animals</Link>
-            <Link href="/animals/admin">Animal admin</Link>
+            <Link href="/animals/dashboard">Animal Dashboard</Link>
           </div>
 
           <span>{data.loggedInAnimalByFirstName?.firstName}</span>


### PR DESCRIPTION
This PR changes the files named with `admin...` to now use `dashboard` as this suits our use case and the decision to stop using the term admin. For example, the `animals/admin/page.tsx` file is now `animals/dashboard/page.tsx`


TODO
- [x] Rename affected files, folders, and functions to dashboard
- [x] CI passes

