### PR TITLE
Remove AnimalResponse type and inline type

### DIFF
--- a/app/animals/dashboard/AnimalForm.tsx
+++ b/app/animals/dashboard/AnimalForm.tsx
@@ -2,7 +2,11 @@
 import { gql, useMutation } from '@apollo/client';
 import { useSuspenseQuery } from '@apollo/experimental-nextjs-app-support/ssr';
 import { useState } from 'react';
-import { AnimalResponse } from '../page';
+import { Animal } from '../../../migrations/00000-createTableAnimals';
+
+export type AnimalResponse = {
+  animals: Animal[];
+};
 
 const createAnimal = gql`
   mutation CreateAnimal(

--- a/app/animals/dashboard/AnimalForm.tsx
+++ b/app/animals/dashboard/AnimalForm.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from '@apollo/experimental-nextjs-app-support/ssr';
 import { useState } from 'react';
 import { Animal } from '../../../migrations/00000-createTableAnimals';
 
-export type AnimalResponse = {
+export type GetAnimalsResponse = {
   animals: Animal[];
 };
 
@@ -73,7 +73,7 @@ export default function AnimalForm() {
   const [accessoryOnEditInput, setAccessoryOnEditInput] = useState('');
   const [onEditId, setOnEditId] = useState<number | undefined>();
 
-  const { data, refetch } = useSuspenseQuery<AnimalResponse>(getAnimals);
+  const { data, refetch } = useSuspenseQuery<GetAnimalsResponse>(getAnimals);
 
   const [createAnimalHandler] = useMutation(createAnimal, {
     variables: {

--- a/app/animals/dashboard/AnimalForm.tsx
+++ b/app/animals/dashboard/AnimalForm.tsx
@@ -4,10 +4,6 @@ import { useSuspenseQuery } from '@apollo/experimental-nextjs-app-support/ssr';
 import { useState } from 'react';
 import { Animal } from '../../../migrations/00000-createTableAnimals';
 
-export type GetAnimalsResponse = {
-  animals: Animal[];
-};
-
 const createAnimal = gql`
   mutation CreateAnimal(
     $firstName: String!
@@ -73,7 +69,7 @@ export default function AnimalForm() {
   const [accessoryOnEditInput, setAccessoryOnEditInput] = useState('');
   const [onEditId, setOnEditId] = useState<number | undefined>();
 
-  const { data, refetch } = useSuspenseQuery<GetAnimalsResponse>(getAnimals);
+  const { data, refetch } = useSuspenseQuery<{ animals: Animal[] }>(getAnimals);
 
   const [createAnimalHandler] = useMutation(createAnimal, {
     variables: {

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -13,6 +13,7 @@ export default async function AnimalsPage() {
         animals {
           id
           firstName
+          type
         }
       }
     `,

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -2,15 +2,7 @@ import { gql } from '@apollo/client';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getClient } from '../../util/apolloClient';
-
-export type AnimalResponse = {
-  animals: {
-    id: number;
-    firstName: string;
-    type: string;
-    accessory: string;
-  }[];
-};
+import { AnimalResponse } from './dashboard/AnimalForm';
 
 export default async function AnimalsPage() {
   const { data } = await getClient().query<AnimalResponse>({

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -1,11 +1,13 @@
 import { gql } from '@apollo/client';
 import Image from 'next/image';
 import Link from 'next/link';
+import { Animal } from '../../migrations/00000-createTableAnimals';
 import { getClient } from '../../util/apolloClient';
-import { AnimalResponse } from './dashboard/AnimalForm';
 
 export default async function AnimalsPage() {
-  const { data } = await getClient().query<AnimalResponse>({
+  const { data } = await getClient().query<{
+    animals: Pick<Animal, 'id' | 'firstName' | 'type'>[];
+  }>({
     query: gql`
       query GetAnimals {
         animals {


### PR DESCRIPTION
Remove the `AnimalResponse` type, as this does not conform to the type of data that is being returned from the GraphQL queries. Use Animal type from the migration file and inline type on usage