### PR TITLE
Use returnTo searchParams for redirect 

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { getSafeReturnToPath } from '../../../util/validation';
 import LoginForm from './LoginForm';
 
-type Props = { searchParams: { returnTo?: string | string[] } };
+type Props = {
+  searchParams: { returnTo?: string | string[] };
+};
 
 export default function LoginPage({ searchParams }: Props) {
   const fakeSessionToken = cookies().get('fakeSession');

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,13 +1,16 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import React from 'react';
+import { getSafeReturnToPath } from '../../../util/validation';
 import LoginForm from './LoginForm';
 
-export default function LoginPage() {
+type Props = { searchParams: { returnTo?: string | string[] } };
+
+export default function LoginPage({ searchParams }: Props) {
   const fakeSessionToken = cookies().get('fakeSession');
 
   if (fakeSessionToken?.value) {
-    redirect('/animals');
+    redirect(getSafeReturnToPath(searchParams.returnTo) || '/');
   }
   return <LoginForm />;
 }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -5,7 +5,9 @@ import { getSafeReturnToPath } from '../../../util/validation';
 import LoginForm from './LoginForm';
 
 type Props = {
-  searchParams: { returnTo?: string | string[] };
+  searchParams: {
+    returnTo?: string | string[];
+  };
 };
 
 export default function LoginPage({ searchParams }: Props) {

--- a/app/animals/dashboard/page.tsx
+++ b/app/animals/dashboard/page.tsx
@@ -21,7 +21,7 @@ export default async function DashboardPage() {
   });
 
   if (!data.loggedInAnimalByFirstName) {
-    redirect('/login');
+    redirect('/login?returnTo=/animals/dashboard');
   }
 
   return <AnimalForm />;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "sass": "^1.69.1",
     "server-only": "^0.0.1",
     "sharp": "^0.32.6",
-    "tsm": "^2.3.0"
+    "tsm": "^2.3.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@ts-safeql/eslint-plugin": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   tsm:
     specifier: ^2.3.0
     version: 2.3.0
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@ts-safeql/eslint-plugin':
@@ -6463,4 +6466,3 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: true

--- a/util/validation.ts
+++ b/util/validation.ts
@@ -1,0 +1,25 @@
+import { Route } from 'next';
+import { z } from 'zod';
+
+const returnToSchema = z.string().refine((value) => {
+  return (
+    !value.startsWith('/logout') &&
+    // Regular expression for valid returnTo path:
+    // - starts with a slash
+    // - until the end of the string, 1 or more:
+    //   - numbers
+    //   - hash symbols
+    //   - forward slashes
+    //   - equals signs
+    //   - question marks
+    //   - lowercase letters
+    //   - dashes
+    /^\/[\d#/=?a-z-]+$/.test(value)
+  );
+});
+
+export function getSafeReturnToPath(path: string | string[] | undefined) {
+  const result = returnToSchema.safeParse(path);
+  if (!result.success) return undefined;
+  return result.data as Route;
+}


### PR DESCRIPTION
Closes: https://github.com/upleveled/graphql-example-fall-2023-atvie/issues/9
This PR adds `returnTo` search params to the `login` page redirect and uses the 
 `getSafeReturnToPath` to redirect to the path returned by the `returnTo`


