### PR TITLE
Refactor database query names

### DIFF
--- a/app/animals/[animalId]/page.tsx
+++ b/app/animals/[animalId]/page.tsx
@@ -1,13 +1,13 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { getAnimalById } from '../../../database/animals';
+import { getAnimalInsecure } from '../../../database/animals';
 
 type Props = {
   params: { animalId: string };
 };
 
 export default async function AnimalPage(props: Props) {
-  const animal = await getAnimalById(Number(props.params.animalId));
+  const animal = await getAnimalInsecure(Number(props.params.animalId));
 
   if (!animal) {
     return (

--- a/app/animals/dashboard/page.tsx
+++ b/app/animals/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getUserBySessionToken } from '../../../database/users';
+import { getUser } from '../../../database/users';
 import AnimalForm from './AnimalForm';
 
 export default async function DashboardPage() {
@@ -9,7 +9,7 @@ export default async function DashboardPage() {
 
   const user =
     insecureSessionTokenCookie &&
-    (await getUserBySessionToken(insecureSessionTokenCookie.value));
+    (await getUser(insecureSessionTokenCookie.value));
 
   if (!user) {
     redirect('/login?returnTo=/animals/dashboard');

--- a/app/animals/page.tsx
+++ b/app/animals/page.tsx
@@ -1,9 +1,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { getAnimals } from '../../database/animals';
+import { getAnimalsInsecure } from '../../database/animals';
 
 export default async function AnimalsPage() {
-  const animals = await getAnimals();
+  const animals = await getAnimalsInsecure();
 
   return (
     <div>

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -78,7 +78,11 @@ const resolvers = {
   },
 
   Mutation: {
-    createAnimal: async (parent: null, args: AnimalInput) => {
+    createAnimal: async (
+      parent: null,
+      args: AnimalInput,
+      context: GraphqlContext,
+    ) => {
       if (
         typeof args.firstName !== 'string' ||
         typeof args.type !== 'string' ||
@@ -88,7 +92,17 @@ const resolvers = {
       ) {
         throw new GraphQLError('Required field is missing');
       }
-      return await createAnimal(args.firstName, args.type, args.accessory);
+
+      if (!context.insecureSessionTokenCookie) {
+        throw new GraphQLError('Unauthorized operation');
+      }
+
+      return await createAnimal(
+        context.insecureSessionTokenCookie.value,
+        args.firstName,
+        args.type,
+        args.accessory,
+      );
     },
 
     deleteAnimal: async (

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -9,8 +9,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
   createAnimal,
   deleteAnimalBySessionToken,
-  getAnimalById,
-  getAnimals,
+  getAnimalInsecure,
+  getAnimalsInsecure,
   updateAnimalBySessionToken,
 } from '../../../database/animals';
 import { Animal } from '../../../migrations/00000-createTableAnimals';
@@ -69,11 +69,11 @@ const typeDefs = gql`
 const resolvers = {
   Query: {
     animals: async () => {
-      return await getAnimals();
+      return await getAnimalsInsecure();
     },
 
     animal: async (parent: null, args: { id: string }) => {
-      return await getAnimalById(Number(args.id));
+      return await getAnimalInsecure(Number(args.id));
     },
   },
 

--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -8,10 +8,10 @@ import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import {
   createAnimal,
-  deleteAnimalBySessionToken,
+  deleteAnimal,
   getAnimalInsecure,
   getAnimalsInsecure,
-  updateAnimalBySessionToken,
+  updateAnimal,
 } from '../../../database/animals';
 import { Animal } from '../../../migrations/00000-createTableAnimals';
 
@@ -99,7 +99,7 @@ const resolvers = {
       if (!context.insecureSessionTokenCookie) {
         throw new GraphQLError('Unauthorized operation');
       }
-      return await deleteAnimalBySessionToken(
+      return await deleteAnimal(
         context.insecureSessionTokenCookie.value,
         Number(args.id),
       );
@@ -123,7 +123,7 @@ const resolvers = {
       ) {
         throw new GraphQLError('Required field missing');
       }
-      return await updateAnimalBySessionToken(
+      return await updateAnimal(
         context.insecureSessionTokenCookie.value,
         Number(args.id),
         args.firstName,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { getUserBySessionToken } from '../database/users';
+import { getUser } from '../database/users';
 import { LogoutButton } from './(auth)/logout/LogoutButton';
 import { ApolloClientProvider } from './ApolloClientProvider';
 
@@ -24,7 +24,7 @@ export default async function RootLayout({
 
   const user =
     insecureSessionTokenCookie &&
-    (await getUserBySessionToken(insecureSessionTokenCookie.value));
+    (await getUser(insecureSessionTokenCookie.value));
 
   return (
     <html lang="en">

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -2,7 +2,7 @@ import { cache } from 'react';
 import { Animal } from '../migrations/00000-createTableAnimals';
 import { sql } from './connect';
 
-export const getAnimals = cache(async () => {
+export const getAnimalsInsecure = cache(async () => {
   const animals = await sql<Animal[]>`
     SELECT
       *
@@ -12,7 +12,7 @@ export const getAnimals = cache(async () => {
   return animals;
 });
 
-export const getAnimalById = cache(async (id: number) => {
+export const getAnimalInsecure = cache(async (id: number) => {
   const [animal] = await sql<Animal[]>`
     SELECT
       *

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -25,10 +25,24 @@ export const getAnimalInsecure = cache(async (id: number) => {
 });
 
 export const createAnimal = cache(
-  async (firstName: string, type: string, accessory: string) => {
+  async (
+    insecureSessionToken: string,
+    firstName: string,
+    type: string,
+    accessory: string,
+  ) => {
+    // FIXME: Remove this early return when proper session token validation is implemented (see FIXME in query below)
+    if (
+      insecureSessionToken !==
+      'ae96c51f--fixme--insecure-hardcoded-session-token--5a3e491b4f'
+    ) {
+      return undefined;
+    }
+
     const [animal] = await sql<Animal[]>`
       INSERT INTO
         animals (first_name, type, accessory)
+        -- FIXME: Implement proper session token validation with INNER JOIN on sessions table
       VALUES
         (
           ${firstName},

--- a/database/animals.ts
+++ b/database/animals.ts
@@ -43,7 +43,7 @@ export const createAnimal = cache(
   },
 );
 
-export const updateAnimalBySessionToken = cache(
+export const updateAnimal = cache(
   async (
     // FIXME: Rename insecureSessionToken to sessionToken everywhere
     insecureSessionToken: string,
@@ -77,7 +77,7 @@ export const updateAnimalBySessionToken = cache(
   },
 );
 
-export const deleteAnimalBySessionToken = cache(
+export const deleteAnimal = cache(
   // FIXME: Rename insecureSessionToken to sessionToken everywhere
   async (insecureSessionToken: string, animalId: number) => {
     // FIXME: Remove this early return when proper session token validation is implemented (see FIXME in query below)

--- a/database/users.ts
+++ b/database/users.ts
@@ -2,7 +2,7 @@ import { cache } from 'react';
 import { User } from '../migrations/00002-createTableUsers';
 import { sql } from './connect';
 
-export const getUserBySessionToken = cache(
+export const getUser = cache(
   // FIXME: Rename insecureSessionToken to sessionToken everywhere
   async (insecureSessionToken: string) => {
     // FIXME: Remove this early return when proper session token validation is implemented (see FIXME in query below)


### PR DESCRIPTION
This PR refactors database query function names to match the new naming convention being applied to the next.js example repo https://github.com/upleveled/next-js-example-fall-2023-atvie/pull/29#discussion_r1474331642

- [x] Add `Insecure` suffix to database queries without session token
- [x] Remove all `BySession...` suffix in all database queries with session token 